### PR TITLE
Fix solr container name

### DIFF
--- a/charts/sitecore930-xm/charts/solr/templates/deployment.yaml
+++ b/charts/sitecore930-xm/charts/solr/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           - name: data
             mountPath: /data
       containers:
-        - name: {{ include "sql.fullName" . }}
+        - name: {{ include "solr.fullName" . }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.tag }}"


### PR DESCRIPTION
I think it was just accidentally changed to ``sql.fullName`` instead of ``solr.fullName`` when maving away from ``.Chart.Name``