### PR TITLE
Support KubeVersion 1.19 without warning

### DIFF
--- a/charts/sitecore930-xm/Chart.yaml
+++ b/charts/sitecore930-xm/Chart.yaml
@@ -4,7 +4,7 @@ description: A Sitecore 9.3.0 XM Helm chart for Kubernetes
 icon: https://mygetwwwsitecoreeu.blob.core.windows.net/feedicons/sc-packages.png?202004140646
 type: application
 kubeVersion: ">= 1.15.0"
-version: 1.1.2
+version: 1.1.3
 appVersion: 9.3.0
 keywords:
   - sitecore

--- a/charts/sitecore930-xm/charts/cd/templates/ingress.yaml
+++ b/charts/sitecore930-xm/charts/cd/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cd.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -34,8 +30,10 @@ spec:
         {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sitecore930-xm/charts/cd/templates/ingress.yaml
+++ b/charts/sitecore930-xm/charts/cd/templates/ingress.yaml
@@ -1,7 +1,13 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cd.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -28,12 +34,20 @@ spec:
       http:
         paths:
         {{- range .paths }}
+          {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
           - path: {{ . }}
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ $fullName }}
                 port: 
                   number: {{ $svcPort }}
+          {{- else -}}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sitecore930-xm/charts/cm/templates/ingress.yaml
+++ b/charts/sitecore930-xm/charts/cm/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "cm.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -32,10 +34,20 @@ spec:
       http:
         paths:
         {{- range .paths }}
+          {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+          - path: {{ . }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $svcPort }}
+          {{- else -}}
           - path: {{ . }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+          {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Updated ingress to support KubeVersion 1.19 without warnings according to https://kubernetes.io/docs/reference/using-api/deprecation-guide/